### PR TITLE
Update semp.conf

### DIFF
--- a/semp.conf
+++ b/semp.conf
@@ -74,7 +74,11 @@
 #stopbits = 1
 
 # Parity setting, relevant if connecting to source over serial.
-# optional, default: e
+# Be carefull: Use capital letter.
+# (E)ven - 1 0 1 0 | P(0)
+# (O)dd  - 1 0 1 0 | P(1)
+# (N)one - 1 0 1 0 | no parity
+# optional, default: E
 #parity = e
 
 # Source meter baud rate, relevant if connecting to source of serial.


### PR DESCRIPTION
Changed the guide text for parity to indicate that you need to use capital letter.